### PR TITLE
Correcion de codigo en la función test_adquisicion_datos()

### DIFF
--- a/C-prototipos/Pruebas_Unitarias/Consumo_de_Energia_Sistema_Hidroponico/test/test_sensor.cpp
+++ b/C-prototipos/Pruebas_Unitarias/Consumo_de_Energia_Sistema_Hidroponico/test/test_sensor.cpp
@@ -20,8 +20,9 @@ void test_inicializacion_sensor() {
 
 // Prueba para verificar la adquisición de datos del sensor
 void test_adquisicion_datos() {
-    corriente = analogRead(sensorPin) * (3.3 / 4095.0) / R;
-    voltaje = analogRead(sensorPin) * (3.3 / 4095.0);
+    int sensorValue = analogRead(sensorPin);
+    corriente = sensorValue * (3.3 / 4095.0) / R;
+    voltaje = sensorValue * (3.3 / 4095.0);
 
     // Verifica que los valores estén dentro de un rango esperado
     TEST_ASSERT_GREATER_OR_EQUAL(0.0, corriente);


### PR DESCRIPTION
La función test_adquisicion_datos() llamaba a analogRead(sensorPin) dos veces (en las líneas 23 y 24), lo que podía generar lecturas inconsistentes del sensor si el valor analógico cambia entre llamadas, para que no pudiese ocurrir eso, considere leer el valor del sensor una vez en una variable temporal y luego calcular tanto "corriente" como "voltaje" con base en esa única lectura.